### PR TITLE
Set version system to use STM since GHC.Event breaks things

### DIFF
--- a/Monky.hs
+++ b/Monky.hs
@@ -51,7 +51,7 @@ import Text.Printf (printf)
 
 -- |Export the version of monky to modules
 getVersion :: (Int, Int, Int, Int)
-getVersion = (1, 2, 0, 2)
+getVersion = (1, 2, 0, 3)
 
 -- |The module wrapper used to buffer output strings
 data ModuleWrapper = MWrapper Modules (IORef String)

--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.2.0.2
+version:             1.2.0.3
 
 -- A short (one-line) description of the package.
 -- synopsis:
@@ -62,7 +62,7 @@ executable monky
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6.0.1 && <=4.8.0.0, directory, process, unix
+  build-depends:       base >=4.6.0.1 && <=4.8.0.0, directory, process, unix, stm
 
   -- Directories containing source files.
   -- hs-source-dirs:
@@ -79,7 +79,7 @@ library
 
   other-modules: Monky.Template Monky.Event
 
-  build-depends:       base >=4.6.0.1 && <=4.8.0.0, directory, time, old-locale, array, text, unix, network, ioctl, mtl, transformers, template-haskell, containers
+  build-depends:       base >=4.6.0.1 && <=4.8.0.0, directory, time, old-locale, array, text, unix, network, ioctl, mtl, transformers, template-haskell, containers, stm
   if impl(ghc < 7.10)
     build-depends: transformers-compat
 


### PR DESCRIPTION
GHC.Event registers the Fd with the event system of the RTS.
This would be fine by itself, but threadWaitRead wants to do the same which crashes because the underlying epoll returns EEXIST
