### PR TITLE
Failable

### DIFF
--- a/Monky/Event.hs
+++ b/Monky/Event.hs
@@ -31,6 +31,8 @@ module Monky.Event
 where
 
 
+import System.Timeout (timeout)
+import Data.Time.Clock.POSIX
 import System.Posix.Types (Fd)
 import Control.Applicative ((<|>))
 import Control.Monad (void)
@@ -38,7 +40,22 @@ import Control.Monad (void)
 import Control.Concurrent
 import Control.Concurrent.STM.TVar
 
+import Monky.Modules
 import Control.Monad.STM
+
+
+type MonkyEvent = (Int, Fd -> IO Bool, Modules)
+type EvtSTM = STM (MonkyEvent, Fd, IO ())
+
+-- The return value will be the MonkyEvent (so we can recreate it if we need to)
+-- and the IO action to rearm the specific event
+data LoopEvt = LoopEvt Int EvtSTM
+instance Eq LoopEvt where
+  (==) (LoopEvt i _) (LoopEvt j _) = i == j
+
+
+getEvt :: LoopEvt -> EvtSTM
+getEvt (LoopEvt _ x) = x
 
 
 armEvent :: TVar Bool -> Fd -> IO ()
@@ -46,51 +63,119 @@ armEvent m fd = do
     atomically $writeTVar m False
     void $forkIO (threadWaitRead fd >> atomically (writeTVar m True))
 
--- variation to threadReadWaitSTM that allows rearming of the STM
-threadWaitReadSTM' :: Fd -> IO (STM(), IO ())
-threadWaitReadSTM' fd = do
+
+threadWaitReadSTME :: Fd -> IO (STM(), Fd, IO ())
+threadWaitReadSTME fd = do
   m <- newTVarIO False
   let rearm = armEvent m fd
   let waitAction = do b <- readTVar m
                       if b then return () else retry
   rearm -- start it once
-  return (waitAction, rearm)
+  return (waitAction, fd, rearm)
 
 
-
-getSTMEvent :: (Fd -> IO ()) -> Fd -> IO (STM (IO ()))
-getSTMEvent act fd = do
-    (event,rearm) <- threadWaitReadSTM' fd
-    return (event >> return (act fd >> rearm))
-
-
-getSTMEvents :: [(Fd -> IO (), [Fd])] -> IO [STM (IO ())]
-getSTMEvents [] = return []
-getSTMEvents ((act, fds):xs) = do
-  events <- mapM (getSTMEvent act) fds
-  others <- getSTMEvents xs
-  return (events ++ others)
-
-
-stmLoop :: STM (IO ()) -> IO ()
-stmLoop events = do
-  act <- atomically events
-  act
-  stmLoop events
-
-
-startSTMEvents :: [(Fd -> IO (), [Fd])] -> IO ()
-startSTMEvents xs = do
-  events <- getSTMEvents xs
+getSTMEventE :: MonkyEvent -> IO (Maybe EvtSTM)
+getSTMEventE evt@(_, _, (MW m _)) = do
+  events <- mapM threadWaitReadSTME =<< getFDs m
   if null events
-    then return ()
-    else stmLoop $foldr1 ((<|>)) events
+    then return Nothing
+    else return . Just . foldr1 ((<|>)) . map createEvent $events
+  where
+    createEvent :: (STM (), Fd, IO ()) -> STM (MonkyEvent, Fd, IO ())
+    createEvent (event, fd, rearm) = do
+      event
+      return (evt, fd, rearm)
+
+
+getSTMEventEs :: [MonkyEvent] -> IO ([LoopEvt], [MonkyEvent])
+getSTMEventEs [] = return ([], [])
+getSTMEventEs (x@(i, _, _):xs) = do
+  (ys,zs) <- getSTMEventEs xs
+  current <- getSTMEventE x
+  case current of
+    Just y -> return (LoopEvt i y:ys, zs)
+    Nothing -> return (ys, x:zs)
+
+
+recover :: [MonkyEvent] -> IO ([LoopEvt], [MonkyEvent])
+recover [] = return ([], [])
+recover (x@(i, _, (MW m _)):xs) = do
+  (ys, zs) <- recover xs
+  putStrLn "Trying to recover module"
+  rec <- recoverModule m
+  if rec
+    then do
+      putStrLn "Recoverd module"
+      (Just evt) <- getSTMEventE x
+      return (LoopEvt i evt:ys,zs)
+    else return (ys, x:zs)
+
+
+stmLoopE :: [LoopEvt] -> [MonkyEvent] -> POSIXTime -> IO ()
+-- This hould not happen
+stmLoopE [] [] _ = return ()
+-- If we have no event we could wait on, why wait?
+-- Plus the main implementation could not handle an empty list
+stmLoopE [] ys _ = do
+  threadDelay (10 * 1000 * 1000)
+  (xs, zs) <- recover ys
+  t <- getPOSIXTime
+  stmLoopE xs zs  t
+-- The main body of the event list
+stmLoopE xs ys t = do
+  t' <- getPOSIXTime
+  if (t' - t) > 5
+    then do
+      (rs, ys') <- recover ys
+      stmLoopE (rs ++ xs) ys' t'
+    else do
+    -- This timeout is significantly higher than the check above
+    -- The event system should not wake up to often
+    -- The only reason this exists is, that we want to be able to recover
+    -- modules even if no other has any action
+      ret <- timeout (30 * 1000 * 1000) $atomically . foldr1 ((<|>)) . map getEvt $xs
+      case ret of
+      -- Nothing means we timed out, so we just restart the loop
+        Nothing -> stmLoopE xs ys t
+      -- Just x means we got an event before we timed out
+        Just (evt@(i, act, _), fd, rearm) -> do
+          suc <- act fd
+          if suc
+          -- rearm and continue loop on success
+            then rearm >> stmLoopE xs ys t
+          -- remove from timeout list and add to recovery list on fail
+            else stmLoopE (filter (rm i) xs) (evt:ys) t
+  where
+    rm i (LoopEvt j _) = i /= j
+
+
+startLoopE :: [MonkyEvent] -> IO ()
+startLoopE xs = do
+  events <- getSTMEventEs xs
+  uncurry stmLoopE events 0
+
+
+createMonkyEvents :: [(Fd -> IO Bool, Modules)] -> [MonkyEvent]
+createMonkyEvents = createMonkyEvents' 0
+  where
+    createMonkyEvents' :: Int -> [(Fd -> IO Bool, Modules)] -> [MonkyEvent]
+    createMonkyEvents' _ [] = []
+    createMonkyEvents' i ((x, y):xs) = (i, x, y) : createMonkyEvents' (i + 1) xs
+
+
 
 {- | Start the event loop
 
 This starts an event loop around the functions given in the list.
 Every time one of the fds becomes readable, the associated function will be
 called with that fd as argument.
+
+ALL entries in the list have to export some fd(s) ofer getFDs!
+
+If getFDs returns [] the module is assumed to be in a broken state
+
+If this is called with an empty list, nothing will be done.
 -}
-startEventLoop :: [(Fd -> IO (), [Fd])] -> IO ()
-startEventLoop xs = forkIO (startSTMEvents xs) >> return ()
+startEventLoop :: [(Fd -> IO Bool, Modules)] -> IO ()
+startEventLoop [] = return ()
+startEventLoop xs = forkIO (startLoopE $createMonkyEvents xs) >> return ()

--- a/Monky/Modules.hs
+++ b/Monky/Modules.hs
@@ -53,6 +53,30 @@ class Module a where
                  -> IO String -- ^The text segment that should be displayed
     getEventText _ = getText
 
+    {- |This is supposed to set up the module
+       This is only needed, if the module may fail
+       so doing nothing should be ok for all *normal* modules
+
+       The module should return 'True' if the setup was successful (is usable)
+       or 'False' if it failed to enter the broken state right at startup
+    -}
+    setupModule :: a -> IO Bool
+    setupModule _ = return True
+
+    {- |This function is a wrapper around 'getText' that allows
+        modules to report a fail and go into a failed state -}
+    getTextFailable :: String -> a -> IO (Maybe String)
+    getTextFailable u h = Just <$> getText u h
+    {- |This function is a wrapper around 'getEventText' that allows
+        modules to report a fail and go into a failed state -}
+    getEventTextFailable :: Fd -> String -> a -> IO (Maybe String)
+    getEventTextFailable f u h = Just <$> getEventText f u h
+
+    {- |If a module failed earlier this will be called in periodicly
+       until the module returns true to indicate a successful recovery -}
+    recoverModule :: a -> IO Bool
+    recoverModule _ = return True
+
 -- |Function to make packaging modules easier
 pack :: Module a
      => Int -- ^The refresh rate for this module

--- a/Monky/Modules.hs
+++ b/Monky/Modules.hs
@@ -17,6 +17,7 @@
     along with Monky.  If not, see <http://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE CPP #-}
 {-|
 Module      : Monky.Modules
 Description : The module definition used by 'startLoop'
@@ -30,6 +31,12 @@ compatible module.
 module Monky.Modules
 (Modules(..), Module(..), pack)
 where
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Control.Applicative ((<$>))
+#endif
+
 
 import System.Posix.Types (Fd)
 

--- a/Monky/Wifi.hs
+++ b/Monky/Wifi.hs
@@ -1,0 +1,24 @@
+module Monky.Wifi
+where
+
+import System.Linux.Netlink.GeNetlink.NL80211
+--import System.Linux.Netlink.GeNetlink.NL80211.Constants
+
+import Data.Word (Word32)
+import Data.Maybe
+
+data WifiHandle = WifiHandle NL80211Socket Word32
+
+getWifiHandle :: String -> IO WifiHandle
+getWifiHandle iface = do
+  sock <- makeNL80211Socket
+  interfaces <- getInterfaceList sock
+  let [(name, iid)] = filter ((== iface) . fst) interfaces
+  return $WifiHandle sock iid
+
+getCurrentWifiName :: WifiHandle -> IO (Maybe String)
+getCurrentWifiName (WifiHandle sock iface) = do
+  connected <- getConnectedWifi sock iface
+  let attrs = mapMaybe getWifiAttributes connected
+  putStrLn $show attrs
+  return Nothing

--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.3.2.0
+version:             1.3.3.0
 
 -- The ABOVE LINE has to stay AS IS (except for version changes) for the
 -- template to work properly


### PR DESCRIPTION
This patch adds a way for modules to fail.

Failing means that some kind of outer influence broke the module. E.g. Network access or a server is not active for MPD module.

For normal modules nothing changes.
For an example of how to implement failable modules look at Monky.Examples.MPD.
