### PR TITLE
Fix memory handle for old kernel

### DIFF
--- a/Monky/Examples/Memory.hs
+++ b/Monky/Examples/Memory.hs
@@ -24,12 +24,18 @@ Maintainer  : ongy, moepi
 Stability   : testing
 Portability : Linux
 
+For older kernels the memory available value may be wrong.
+When not provided by the kernel it's computed as `free + cached + buffers`.
+If you find this to be to inacurate, use the version for memory free.
+But be aware, that free memory on linux can go close to zero because of io buffers.
 -}
 module Monky.Examples.Memory
   ( getMemoryHandle
   , getMemoryBarHandle
+  , getMemoryFreeHandle
 
   , MHandle
+  , MFHandle
   , MBHandle
   )
 where
@@ -43,7 +49,7 @@ import qualified Monky.Memory as M (getMemoryHandle)
 -- |Simple handle to display current memory available
 newtype MHandle = MH MemoryHandle
 
--- |Get the the memory handle
+-- |Get the the memory handle (available)
 getMemoryHandle :: IO MHandle
 getMemoryHandle = fmap MH $ M.getMemoryHandle
 
@@ -51,6 +57,23 @@ getMemoryHandle = fmap MH $ M.getMemoryHandle
 instance PollModule MHandle where
   getOutput (MH h) = do
     mp <- getMemoryAvailable h
+    return
+      [ MonkyImage "mem" '🐏'
+      , MonkyPlain $ convertUnitB (mp * 1024) "B"
+      ]
+
+
+-- |Simple handle to display current free memory
+newtype MFHandle = MFH MemoryHandle
+
+-- |Get the the memory handle (free)
+getMemoryFreeHandle :: IO MFHandle
+getMemoryFreeHandle = fmap MFH $ M.getMemoryHandle
+
+{- Memory Module -}
+instance PollModule MFHandle where
+  getOutput (MFH h) = do
+    mp <- getMemoryFree h
     return
       [ MonkyImage "mem" '🐏'
       , MonkyPlain $ convertUnitB (mp * 1024) "B"

--- a/Monky/Memory.hs
+++ b/Monky/Memory.hs
@@ -69,7 +69,7 @@ getMemoryAvailable (MemoryH f) = do
 
     Nothing -> do
       let buffs = fromMaybe err $ findLine "Buffers" contents
-          cached = fromMaybe err $ findLine "Chached" contents
+          cached = fromMaybe err $ findLine "Cached" contents
       free <- getMemoryFree (MemoryH f)
       return $ getVal buffs + getVal cached + free
     (Just x) -> return . getVal $ x

--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.0.0.0
+version:             2.0.0.1
 
 -- The ABOVE LINE has to stay AS IS (except for version changes) for the
 -- template to work properly


### PR DESCRIPTION
Old linux kernel (~3.15 fixes that I guess) don't export `MemAvailable` in `/proc/cpuinfo` so we can't rely on having it.
Use `free + cached + buffers` as fallback if `MemAvailable` is not present.
