### PR TITLE
Pulseaudio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ matrix:
   include:
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3, libpulse-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4, libpulse-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.2
       compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2, libpulse-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1, libpulse-dev], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3, libpulse-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.20,ghc-7.6.3, libpulse-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4, libpulse-dev], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.6.3, libpulse-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3, libpulse-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4, libpulse-dev], sources: [hvr-ghc]}}

--- a/Monky/Examples/Alsa.hs
+++ b/Monky/Examples/Alsa.hs
@@ -16,57 +16,18 @@
     You should have received a copy of the GNU Lesser General Public License
     along with Monky.  If not, see <http://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE OverloadedStrings #-}
 {-|
 Module      : Monky.Examples.Alsa
-Description : An example module instance for the alsa module
+Description : Proxy module for backwards compat. See Monky.Examples.Sound.Alsa
 Maintainer  : ongy
 Stability   : testing
 Portability : Linux
 
 -}
-module Monky.Examples.Alsa
+module Monky.Examples.Alsa {-# DEPRECATED "Use Monky.Examples.Sound.Alsa" #-}
   ( getVOLHandle
   , AlsaH
   )
 where
 
-import Monky.Alsa hiding (getVOLHandle)
-import qualified Monky.Alsa as A (getVOLHandle)
-import Monky.Modules
-import Monky.Examples.Utility
-
-import Formatting
-import Data.Text (Text)
-
-{- ALSA module -}
-getVolumeStr :: VOLHandle -> IO Text
-getVolumeStr h = do
-  updateVOLH h
-  m <- getMute h
-  v <- getVolumePercent h
-  if m
-    then return "Mute"
-    else return $ sformat ((left 3 ' ' %. int) % "%") v
-
-getVOLOutput :: VOLHandle -> IO [MonkyOut]
-getVOLOutput h = do
-  out <- getVolumeStr h
-  return [MonkyPlain out]
-
-instance PollModule AlsaH where
-  getOutput (AH h) = getVOLOutput h
-
-instance EvtModule AlsaH where
-  startEvtLoop (AH h) r = do
-    [fd] <- getPollFDs h
-    r =<< getOutput (AH h)
-    loopFd h fd r getVOLOutput
-
--- |The handle type for this module
-newtype AlsaH = AH VOLHandle
-
--- |Get a handle which allows access to audio (alsa) subsystem information
-getVOLHandle :: String -- ^The audio-card to use
-             -> IO AlsaH
-getVOLHandle = fmap AH . A.getVOLHandle
+import Monky.Examples.Sound.Alsa

--- a/Monky/Examples/Sound/Alsa.hs
+++ b/Monky/Examples/Sound/Alsa.hs
@@ -1,0 +1,72 @@
+{-
+    Copyright 2015,2016 Markus Ongyerth
+
+    This file is part of Monky.
+
+    Monky is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Monky is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Monky.  If not, see <http://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-|
+Module      : Monky.Examples.Sound.Alsa
+Description : An example module instance for the alsa module
+Maintainer  : ongy
+Stability   : testing
+Portability : Linux
+
+-}
+module Monky.Examples.Sound.Alsa
+  ( getVOLHandle
+  , AlsaH
+  )
+where
+
+import Monky.Alsa hiding (getVOLHandle)
+import qualified Monky.Alsa as A (getVOLHandle)
+import Monky.Modules
+import Monky.Examples.Utility
+
+import Formatting
+import Data.Text (Text)
+
+{- ALSA module -}
+getVolumeStr :: VOLHandle -> IO Text
+getVolumeStr h = do
+  updateVOLH h
+  m <- getMute h
+  v <- getVolumePercent h
+  if m
+    then return "Mute"
+    else return $ sformat ((left 3 ' ' %. int) % "%") v
+
+getVOLOutput :: VOLHandle -> IO [MonkyOut]
+getVOLOutput h = do
+  out <- getVolumeStr h
+  return [MonkyPlain out]
+
+instance PollModule AlsaH where
+  getOutput (AH h) = getVOLOutput h
+
+instance EvtModule AlsaH where
+  startEvtLoop (AH h) r = do
+    [fd] <- getPollFDs h
+    r =<< getOutput (AH h)
+    loopFd h fd r getVOLOutput
+
+-- |The handle type for this module
+newtype AlsaH = AH VOLHandle
+
+-- |Get a handle which allows access to audio (alsa) subsystem information
+getVOLHandle :: String -- ^The audio-card to use
+             -> IO AlsaH
+getVOLHandle = fmap AH . A.getVOLHandle

--- a/Monky/Examples/Sound/Pulse.hs
+++ b/Monky/Examples/Sound/Pulse.hs
@@ -18,6 +18,7 @@
 -}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 {-|
 Module      : Monky.Examples.Sound.Pulse
 Description : Integration example for pulseaudio library.
@@ -57,6 +58,11 @@ import System.IO (hPutStrLn, stderr)
 import Data.Word (Word32)
 import Data.List (genericLength)
 import Formatting
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Control.Applicative ((<$>), (<*>))
+#endif
 
 -- |Pulse handle.
 -- This module uses continuations, the handle is not really used

--- a/Monky/Examples/Sound/Pulse.hs
+++ b/Monky/Examples/Sound/Pulse.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Monky.Examples.Sound.Pulse
+    ( PulseH
+
+    , startPulse
+    , startPulseMaybe
+    , getPulseHandle
+    )
+where
+
+import Monky.Modules
+import Data.Maybe (fromMaybe)
+import Control.Monad (void)
+import Control.Concurrent.MVar
+import Control.Concurrent
+
+import Sound.Pulse.Context
+import Sound.Pulse.Mainloop
+import Sound.Pulse.Mainloop.Simple
+
+import Sound.Pulse.Volume
+import Sound.Pulse.Subscribe
+import Sound.Pulse.Serverinfo
+import Sound.Pulse.Sinkinfo
+
+import System.IO (hPutStrLn, stderr)
+import Data.Word (Word32)
+import Data.List (genericLength)
+import Formatting
+
+data PulseH = PulseH (Maybe String)
+
+printSink :: ([MonkyOut] -> IO ()) -> Sinkinfo -> IO ()
+printSink fun sink = do
+    let vol = cVolumeToLinear $ siVolume sink
+    let baseV = volumeToLinear $ siBaseVolume sink
+    let mute = siMute sink
+    let rvols =  map (\v -> v / baseV * 100) vol
+    let rvol = sum rvols / genericLength rvols
+    let str = if mute
+        then "Mute"
+        else sformat ((left 3 ' ' %. int) % "%") (round rvol :: Int)
+    fun [MonkyPlain str]
+
+
+startLoop :: Context -> ([MonkyOut] -> IO ()) -> Sinkinfo -> IO ()
+startLoop cxt cfun info = do 
+    void $ subscribeEvents cxt [SubscriptionMaskSink] fun
+    printSink cfun info
+    where fun :: ((SubscriptionEventFacility, SubscriptionEventType) -> Word32 -> IO ())
+          fun _ 0 = void $ getContextSinkByIndex cxt (siIndex info) (printSink cfun)
+          fun _ _ = return ()
+
+
+startWithName :: Context -> String -> ([MonkyOut] -> IO ()) -> IO ()
+startWithName cxt name fun = void $ getContextSinkByName cxt name (startLoop cxt fun)
+
+
+getDefaultSink :: Context -> ([MonkyOut] -> IO ()) -> IO ()
+getDefaultSink cxt cfun = void $ getServerInfo cxt fun
+    where fun :: ServerInfo -> IO ()
+          fun serv = let name = defaultSinkName serv
+                     in startWithName cxt name cfun
+
+
+startPulse :: Maybe String -> ([MonkyOut] -> IO ()) -> IO ()
+startPulse = startPulseMaybe (return ())
+
+
+startPulseMaybe
+    :: IO () -- ^The continuation if everything fails
+    -> Maybe String -- ^Sink to use (Nothing for default)
+    -> ([MonkyOut] -> IO ()) -- ^Output function
+    -> IO ()
+startPulseMaybe ret sinkName fun = do
+    impl <- getMainloopImpl
+    cxt <- getContext impl "monky" -- should we get the exe name?
+    setStateCallback cxt $ do
+        state <- getContextState cxt
+        case state of
+            ContextFailed -> do
+                hPutStrLn stderr "Could not connect to pulse :("
+                quitLoop impl (-1)
+            ContextReady -> fromMaybe
+                (getDefaultSink cxt fun )
+                (startWithName cxt <$> sinkName <*> return fun)
+            _ -> return ()
+    _ <- connectContext cxt Nothing []
+    _ <- doLoop impl
+    ret
+
+instance EvtModule PulseH where
+    startEvtLoop (PulseH server) fun = startPulseMaybe (fun [MonkyPlain "None"]) server fun
+
+
+startSyncPulse
+    :: IO Bool
+startSyncPulse = do
+    impl <- getMainloopImpl
+    cxt <- getContext impl "monky" -- should we get the exe name?
+    var <- newEmptyMVar
+    setStateCallback cxt $ do
+        state <- getContextState cxt
+        case state of
+            ContextFailed -> do
+                hPutStrLn stderr "Could not connect to pulse :("
+                quitLoop impl (-1)
+                putMVar var False
+            ContextReady ->
+                putMVar var True
+            _ -> return ()
+    _ <- connectContext cxt Nothing []
+    _ <- forkIO . void $ doLoop impl
+    -- Should we care?
+    readMVar var
+
+instance PollModule PulseH where
+    initialize (PulseH _) = do
+        running <- startSyncPulse
+        if running
+           then return ()
+           else return ()
+    getOutput _ = return []
+
+getPulseHandle :: Maybe String -> IO PulseH
+getPulseHandle = return . PulseH

--- a/Monky/Examples/Sound/Pulse.hs
+++ b/Monky/Examples/Sound/Pulse.hs
@@ -1,5 +1,32 @@
+{-
+    Copyright 2016 Markus Ongyerth
+
+    This file is part of Monky.
+
+    Monky is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Monky is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Monky.  If not, see <http://www.gnu.org/licenses/>.
+-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-|
+Module      : Monky.Examples.Sound.Pulse
+Description : Integration example for pulseaudio library.
+Maintainer  : ongy
+Stability   : experimental
+Portability : Linux
+
+Some of this may move into Monky.Sound.Pulse in a near-ish future.
+-}
 module Monky.Examples.Sound.Pulse
     ( PulseH
 
@@ -15,6 +42,8 @@ import Control.Monad (void)
 import Control.Concurrent.MVar
 import Control.Concurrent
 
+import System.Environment (getProgName)
+
 import Sound.Pulse.Context
 import Sound.Pulse.Mainloop
 import Sound.Pulse.Mainloop.Simple
@@ -29,21 +58,26 @@ import Data.Word (Word32)
 import Data.List (genericLength)
 import Formatting
 
+-- |Pulse handle.
+-- This module uses continuations, the handle is not really used
 data PulseH = PulseH (Maybe String)
 
+-- |Format a given sink to the output string.
 printSink :: ([MonkyOut] -> IO ()) -> Sinkinfo -> IO ()
 printSink fun sink = do
-    let vol = cVolumeToLinear $ siVolume sink
-    let baseV = volumeToLinear $ siBaseVolume sink
+    let norm = 0x10000
+    let (CVolume vol) = siVolume sink
     let mute = siMute sink
-    let rvols =  map (\v -> v / baseV * 100) vol
+    -- this is taken from pulseaudio pa_volume_snprint, +- rounding this is
+    -- equal to pavucontrol
+    let rvols =  map (\v -> (fromIntegral v*100+norm/2) / norm) vol
     let rvol = sum rvols / genericLength rvols
     let str = if mute
         then "Mute"
         else sformat ((left 3 ' ' %. int) % "%") (round rvol :: Int)
     fun [MonkyPlain str]
 
-
+-- |Start the subscription loop that will give us the updates.
 startLoop :: Context -> ([MonkyOut] -> IO ()) -> Sinkinfo -> IO ()
 startLoop cxt cfun info = do 
     void $ subscribeEvents cxt [SubscriptionMaskSink] fun
@@ -52,22 +86,23 @@ startLoop cxt cfun info = do
           fun _ 0 = void $ getContextSinkByIndex cxt (siIndex info) (printSink cfun)
           fun _ _ = return ()
 
-
+-- |Use the name (string) to find the index, print once and find the main loop
 startWithName :: Context -> String -> ([MonkyOut] -> IO ()) -> IO ()
 startWithName cxt name fun = void $ getContextSinkByName cxt name (startLoop cxt fun)
 
-
+-- |Get the default sink and start the main loop
 getDefaultSink :: Context -> ([MonkyOut] -> IO ()) -> IO ()
 getDefaultSink cxt cfun = void $ getServerInfo cxt fun
     where fun :: ServerInfo -> IO ()
           fun serv = let name = defaultSinkName serv
                      in startWithName cxt name cfun
 
-
+-- |Try to start pulse loop. silently fail!
 startPulse :: Maybe String -> ([MonkyOut] -> IO ()) -> IO ()
 startPulse = startPulseMaybe (return ())
 
 
+-- |Connect to pulse server and try to start the main loop for this module.
 startPulseMaybe
     :: IO () -- ^The continuation if everything fails
     -> Maybe String -- ^Sink to use (Nothing for default)
@@ -75,7 +110,8 @@ startPulseMaybe
     -> IO ()
 startPulseMaybe ret sinkName fun = do
     impl <- getMainloopImpl
-    cxt <- getContext impl "monky" -- should we get the exe name?
+    name <- getProgName
+    cxt <- getContext impl name
     setStateCallback cxt $ do
         state <- getContextState cxt
         case state of
@@ -115,13 +151,17 @@ startSyncPulse = do
     -- Should we care?
     readMVar var
 
-instance PollModule PulseH where
-    initialize (PulseH _) = do
-        running <- startSyncPulse
-        if running
-           then return ()
-           else return ()
-    getOutput _ = return []
+-- This (most of it) should move into pulseaudio package, not doing that yet.
+-- instance PollModule PulseH where
+--     initialize (PulseH _) = do
+--         running <- startSyncPulse
+--         if running
+--            then return ()
+--            else return ()
+--     getOutput _ = return []
 
-getPulseHandle :: Maybe String -> IO PulseH
+-- |Get the handle for pulse integration.
+getPulseHandle
+    :: Maybe String -- ^The servername (Nothing will use environment variable)
+    -> IO PulseH
 getPulseHandle = return . PulseH

--- a/Monky/Examples/Sound/Pulse.hs
+++ b/Monky/Examples/Sound/Pulse.hs
@@ -65,7 +65,7 @@ data PulseH = PulseH (Maybe String)
 -- |Format a given sink to the output string.
 printSink :: ([MonkyOut] -> IO ()) -> Sinkinfo -> IO ()
 printSink fun sink = do
-    let norm = 0x10000
+    let norm = 0x10000 :: Double
     let (CVolume vol) = siVolume sink
     let mute = siMute sink
     -- this is taken from pulseaudio pa_volume_snprint, +- rounding this is
@@ -130,26 +130,26 @@ instance EvtModule PulseH where
     startEvtLoop (PulseH server) fun = startPulseMaybe (fun [MonkyPlain "None"]) server fun
 
 
-startSyncPulse
-    :: IO Bool
-startSyncPulse = do
-    impl <- getMainloopImpl
-    cxt <- getContext impl "monky" -- should we get the exe name?
-    var <- newEmptyMVar
-    setStateCallback cxt $ do
-        state <- getContextState cxt
-        case state of
-            ContextFailed -> do
-                hPutStrLn stderr "Could not connect to pulse :("
-                quitLoop impl (-1)
-                putMVar var False
-            ContextReady ->
-                putMVar var True
-            _ -> return ()
-    _ <- connectContext cxt Nothing []
-    _ <- forkIO . void $ doLoop impl
-    -- Should we care?
-    readMVar var
+--startSyncPulse
+--    :: IO Bool
+--startSyncPulse = do
+--    impl <- getMainloopImpl
+--    cxt <- getContext impl "monky" -- should we get the exe name?
+--    var <- newEmptyMVar
+--    setStateCallback cxt $ do
+--        state <- getContextState cxt
+--        case state of
+--            ContextFailed -> do
+--                hPutStrLn stderr "Could not connect to pulse :("
+--                quitLoop impl (-1)
+--                putMVar var False
+--            ContextReady ->
+--                putMVar var True
+--            _ -> return ()
+--    _ <- connectContext cxt Nothing []
+--    _ <- forkIO . void $ doLoop impl
+--    -- Should we care?
+--    readMVar var
 
 -- This (most of it) should move into pulseaudio package, not doing that yet.
 -- instance PollModule PulseH where

--- a/monky.cabal
+++ b/monky.cabal
@@ -98,7 +98,7 @@ Flag ibus
 
 Flag pulse
   Description: enable pulse example
-  Default: true
+  Default: True
 
 Source-repository head
   type:       git

--- a/monky.cabal
+++ b/monky.cabal
@@ -96,6 +96,10 @@ Flag ibus
   Description: enable ibus example
   Default: False
 
+Flag pulse
+  Description: enable pulse example
+  Default: true
+
 Source-repository head
   type:       git
   location:   https://github.com/monky-hs/monky
@@ -135,7 +139,6 @@ library
   exposed-modules: Monky.Examples.Connectivity Monky.Network.Dynamic
   exposed-modules: Monky.Network.Static Monky.Examples.File Monky.Examples.Utility
   exposed-modules: Monky.Examples.Sound.Alsa  Monky.Examples.Alsa 
-  exposed-modules: Monky.Examples.Sound.Pulse
 
   exposed-modules: Monky.Version Monky.Examples.Combine
   exposed-modules: Monky.Examples.Plain Monky.Disk.Common Monky.Blkid
@@ -152,7 +155,7 @@ library
   build-depends:       text, unix, network, mtl, transformers, text
   build-depends:       template-haskell, containers, stm, statvfs
   build-depends:       bytestring, netlink, cereal, formatting, composition
-  build-depends:       env-locale >= 1.0.0.1, pulseaudio
+  build-depends:       env-locale >= 1.0.0.1
 
   -- force double-conversion version for old ghc/library?
   if impl(ghc < 7.8)
@@ -167,6 +170,10 @@ library
   if flag(ibus)
     build-depends: ibus-hs, dbus
     exposed-modules: Monky.Examples.IBus
+
+  if flag(pulse)
+    build-depends: pulseaudio
+    exposed-modules: Monky.Examples.Sound.Pulse
 
   ghc-options:         -Wall
   extra-libraries:     

--- a/monky.cabal
+++ b/monky.cabal
@@ -97,7 +97,7 @@ Flag ibus
   Default: False
 
 Flag pulse
-  Description: enable pulse example
+  Description: enable pulse example (7.6 disabled because travis)
   Default: True
 
 Source-repository head
@@ -171,9 +171,10 @@ library
     build-depends: ibus-hs, dbus
     exposed-modules: Monky.Examples.IBus
 
-  if flag(pulse)
-    build-depends: pulseaudio
-    exposed-modules: Monky.Examples.Sound.Pulse
+  if impl(ghc >= 7.8)
+    if flag(pulse)
+      build-depends: pulseaudio
+      exposed-modules: Monky.Examples.Sound.Pulse
 
   ghc-options:         -Wall
   extra-libraries:     

--- a/monky.cabal
+++ b/monky.cabal
@@ -128,12 +128,14 @@ executable monky
 
 library
   exposed-modules: Monky.Disk Monky.Modules Monky.Time Monky.CPU Monky.Memory Monky.Network Monky.Utility Monky.Alsa Monky.Battery Monky
-  exposed-modules: Monky.Examples.Alsa Monky.Examples.Battery Monky.Examples.CPU Monky.Examples.Disk Monky.Examples.Network Monky.Examples.Time Monky.Examples.Memory
+  exposed-modules: Monky.Examples.Battery Monky.Examples.CPU Monky.Examples.Disk Monky.Examples.Network Monky.Examples.Time Monky.Examples.Memory
   exposed-modules: Monky.Disk.Btrfs Monky.Disk.Device
   exposed-modules: Monky.Examples.Prepend Monky.Connectivity
   exposed-modules: Monky.Wifi Monky.Examples.Wifi
   exposed-modules: Monky.Examples.Connectivity Monky.Network.Dynamic
   exposed-modules: Monky.Network.Static Monky.Examples.File Monky.Examples.Utility
+  exposed-modules: Monky.Examples.Sound.Alsa  Monky.Examples.Alsa 
+  exposed-modules: Monky.Examples.Sound.Pulse
 
   exposed-modules: Monky.Version Monky.Examples.Combine
   exposed-modules: Monky.Examples.Plain Monky.Disk.Common Monky.Blkid
@@ -150,7 +152,7 @@ library
   build-depends:       text, unix, network, mtl, transformers, text
   build-depends:       template-haskell, containers, stm, statvfs
   build-depends:       bytestring, netlink, cereal, formatting, composition
-  build-depends:       env-locale >= 1.0.0.1
+  build-depends:       env-locale >= 1.0.0.1, pulseaudio
 
   -- force double-conversion version for old ghc/library?
   if impl(ghc < 7.8)


### PR DESCRIPTION
Add pulseaudio integration.

this is an addition to the Alsa module.
It deprecates the current alsa example in `Monky.Examples.Alsa`. It will still work, but using it will put out a warning to move to `Monky.Examples.Sound.Alsa`
