### PR TITLE
Handle link quality in wifi module

### DIFF
--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.0.1.2
+version:             2.1.0.0
 
 -- The ABOVE LINE has to stay AS IS (except for version changes) for the
 -- template to work properly


### PR DESCRIPTION
Properly do link quality for wifi networks.
As mentioned in the haddock, this is still somewhat slow and weird for reasons I don't know.

This also fixes `Monky.Examples.Wifi` `PollModule` instance.
