### PR TITLE
Better eventing

### DIFF
--- a/Monky.hs
+++ b/Monky.hs
@@ -34,11 +34,13 @@ other functions later on.
 -}
 module Monky
   ( startLoop
+  , startLoopT
   )
 where
 
-
-import Control.Concurrent (threadDelay)
+import System.Timeout
+import Data.Time.Clock.POSIX
+import Control.Concurrent.MVar
 import Data.IORef (IORef, readIORef, writeIORef, newIORef, atomicWriteIORef)
 import Monky.Modules
 import Control.Monad (when)
@@ -48,15 +50,17 @@ import Control.Concurrent (forkIO)
 data ModuleWrapper = MWrapper Modules (IORef [MonkyOut])
 
 -- |Packs a module into a wrapper with an IORef for cached output
-packMod :: Modules -> IO ModuleWrapper
-packMod x@(Poll (NMW m _)) = do
-  sref <- newIORef []
-  initialize m
-  return (MWrapper x sref)
-packMod x@(Evt (DW m)) = do
-  sref <- newIORef []
-  _ <- forkIO (startEvtLoop m (atomicWriteIORef sref))
-  return $ MWrapper x sref
+packMod :: MVar Bool -> Modules -> IO ModuleWrapper
+packMod _ x@(Poll (NMW m _)) = do
+    sref <- newIORef []
+    initialize m
+    return (MWrapper x sref)
+packMod mvar x@(Evt (DW m)) = do
+    sref <- newIORef []
+    _ <- forkIO . startEvtLoop m $ \val -> do
+        atomicWriteIORef sref val
+        putMVar mvar True
+    return $ MWrapper x sref
 
 getWrapperText :: Int -> ModuleWrapper -> IO [MonkyOut]
 getWrapperText tick (MWrapper (Poll (NMW m i)) r) = do
@@ -68,16 +72,51 @@ doMonkyLine :: MonkyOutput o => Int -> o -> [ModuleWrapper] -> IO ()
 doMonkyLine t o xs =
   doLine o =<< mapM (getWrapperText t) xs
 
-mainLoop :: MonkyOutput o => Int -> o -> [ModuleWrapper] -> IO ()
-mainLoop t o xs = do
-  doMonkyLine t o xs
-  threadDelay 1000000
-  mainLoop (t+1) o xs
+doCachedLine :: MonkyOutput o => o -> [ModuleWrapper] -> IO ()
+doCachedLine out xs =
+    doLine out =<< mapM (\(MWrapper _ r) -> readIORef r) xs
 
--- |Start the mainLoop of monky. This should be the return type of your main
+waitTick :: MonkyOutput o => Int -> MVar Bool -> o -> [ModuleWrapper] -> IO ()
+waitTick limit mvar out xs = do
+    pre <- getPOSIXTime
+    ret <- timeout limit $ takeMVar mvar
+    case ret of
+        Nothing -> return ()
+        Just _ -> do
+            doCachedLine out xs
+            post <- getPOSIXTime
+            let passed = round . (* 1000000) $ post - pre
+            if passed > limit
+                then return ()
+                else waitTick (limit - passed) mvar out xs
+
+mainLoop :: MonkyOutput o => Int -> MVar Bool -> Int -> o -> [ModuleWrapper] -> IO ()
+mainLoop l r t o xs = do
+  doMonkyLine t o xs
+  waitTick l r o xs
+  mainLoop l r (t+1) o xs
+
+{- | Start the mainLoop of monky. With custom tick timer (in μs)
+
+For 1s tick-timer pass @1000000@ to this.
+This does not scale the timers for collection modules passed into it.
+So if @500000@ is passed here, and a collector should update every second
+it needs to update every 2nd tick, so it has to be scaled.
+
+@
+    startLoop getAsciiOut [ pollPack 1 $ getRawCPU ]
+
+    startLoopT 500000 getAsciiOut [ pollPack 2 $ getRawCPU ]
+@
+-}
+startLoopT :: MonkyOutput o => Int -> IO o -> [IO Modules] -> IO ()
+startLoopT t out mods = do
+    mvar <- newEmptyMVar
+    m <- sequence mods
+    l <- mapM (packMod mvar) m
+    o <- out
+    mainLoop t mvar 0 o l
+
+-- | Start the mainLoop of monky. This should be the return type of your main
 startLoop :: MonkyOutput o => IO o -> [IO Modules] -> IO ()
-startLoop o mods = do
-  m <- sequence mods
-  l <- mapM packMod m
-  out <- o
-  mainLoop 0 out l
+startLoop out mods = startLoopT 1000000 out mods

--- a/Monky.hs
+++ b/Monky.hs
@@ -33,9 +33,9 @@ To use them, get the handle at the beginning of you application and hand it to
 other functions later on.
 -}
 module Monky
-  ( startLoop
-  , startLoopT
-  )
+    ( startLoop
+    , startLoopT
+    )
 where
 
 import System.Timeout
@@ -64,13 +64,13 @@ packMod mvar x@(Evt (DW m)) = do
 
 getWrapperText :: Int -> ModuleWrapper -> IO [MonkyOut]
 getWrapperText tick (MWrapper (Poll (NMW m i)) r) = do
-  when (tick `mod` i == 0) (writeIORef r =<< getOutput m)
-  readIORef r
+    when (tick `mod` i == 0) (writeIORef r =<< getOutput m)
+    readIORef r
 getWrapperText _ (MWrapper (Evt _) r) = readIORef r
 
 doMonkyLine :: MonkyOutput o => Int -> o -> [ModuleWrapper] -> IO ()
 doMonkyLine t o xs =
-  doLine o =<< mapM (getWrapperText t) xs
+    doLine o =<< mapM (getWrapperText t) xs
 
 doCachedLine :: MonkyOutput o => o -> [ModuleWrapper] -> IO ()
 doCachedLine out xs =
@@ -92,9 +92,9 @@ waitTick limit mvar out xs = do
 
 mainLoop :: MonkyOutput o => Int -> MVar Bool -> Int -> o -> [ModuleWrapper] -> IO ()
 mainLoop l r t o xs = do
-  doMonkyLine t o xs
-  waitTick l r o xs
-  mainLoop l r (t+1) o xs
+    doMonkyLine t o xs
+    waitTick l r o xs
+    mainLoop l r (t+1) o xs
 
 {- | Start the mainLoop of monky. With custom tick timer (in μs)
 

--- a/Monky.hs
+++ b/Monky.hs
@@ -43,7 +43,7 @@ import Data.Time.Clock.POSIX
 import Control.Concurrent.MVar
 import Data.IORef (IORef, readIORef, writeIORef, newIORef, atomicWriteIORef)
 import Monky.Modules
-import Control.Monad (when)
+import Control.Monad (when, void)
 import Control.Concurrent (forkIO)
 
 
@@ -59,7 +59,7 @@ packMod mvar x@(Evt (DW m)) = do
     sref <- newIORef []
     _ <- forkIO . startEvtLoop m $ \val -> do
         atomicWriteIORef sref val
-        putMVar mvar True
+        void $ tryPutMVar mvar True
     return $ MWrapper x sref
 
 getWrapperText :: Int -> ModuleWrapper -> IO [MonkyOut]

--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.1.1.1
+version:             2.1.2.0
 
 -- The ABOVE LINE has to stay AS IS (except for version changes) for the
 -- template to work properly


### PR DESCRIPTION
The current way monky handles event based modules, is purely for performance i.e. it doesn't update the line when an event is triggered.

With this patch monky will print a new line whenever an event is triggered, without advancing the tick timer, so polling modules will not be messed up.