### PR TITLE
Switch to Monad Pulse for the pulseaudio example

### DIFF
--- a/monky.cabal
+++ b/monky.cabal
@@ -174,7 +174,7 @@ library
 
   if impl(ghc >= 7.8)
     if flag(pulse)
-      build-depends: pulseaudio
+      build-depends: pulseaudio >= 0.0.2.0 && < 0.1.0.0
       exposed-modules: Monky.Examples.Sound.Pulse
 
   ghc-options:         -Wall


### PR DESCRIPTION
The pulseaudio package got a new Monad Pulse, that makes code using it
less of a callback mess. So we use it with our module.