### PR TITLE
Makes section dividers configurable for Dzen, Ascii, Utf8 and Guess outputs

### DIFF
--- a/Monky/Outputs/Ascii.hs
+++ b/Monky/Outputs/Ascii.hs
@@ -17,7 +17,6 @@
     along with Monky.  If not, see <http://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-|
 Module      : Monky.Outputs.Ascii
 Description : Output module for Ascii
@@ -30,6 +29,7 @@ This module provides the output generation for ascii outputs
 module Monky.Outputs.Ascii
   ( AsciiOutput
   , getAsciiOut
+  , getAsciiOut'
   )
 where
 
@@ -39,7 +39,7 @@ import Monky.Modules
 import qualified Data.Text.IO as T
 
 -- |The output handle for a ascii pipe
-data AsciiOutput = AsciiOutput
+data AsciiOutput = AsciiOutput MonkyOut
 
 doOut :: MonkyOut -> IO ()
 doOut (MonkyPlain t)   = T.putStr t
@@ -57,11 +57,17 @@ instance MonkyOutput AsciiOutput where
     doSegment x
     putStr "\n"
     hFlush stdout
-  doLine h (x:xs) = do
+  doLine h@(AsciiOutput d) (x:xs) = do
     doSegment x
-    putStr " | "
+    doOut d
     doLine h xs
 
--- |Get an output handle for ascii formatting
+-- |Get an output handle for ascii formatting. Divider Defaults to " | "
 getAsciiOut :: IO AsciiOutput
-getAsciiOut = return AsciiOutput
+getAsciiOut = getAsciiOut' $ MonkyPlain " | "
+
+-- |Get an output handle for ascii formatting
+getAsciiOut'
+  :: MonkyOut -- ^The Divider
+  -> IO AsciiOutput
+getAsciiOut' = return . AsciiOutput

--- a/Monky/Outputs/Ascii.hs
+++ b/Monky/Outputs/Ascii.hs
@@ -29,7 +29,7 @@ This module provides the output generation for ascii outputs
 module Monky.Outputs.Ascii
   ( AsciiOutput
   , getAsciiOut
-  , getAsciiOut'
+  , getAsciiOutDiv
   )
 where
 
@@ -64,10 +64,10 @@ instance MonkyOutput AsciiOutput where
 
 -- |Get an output handle for ascii formatting. Divider Defaults to @" | "@
 getAsciiOut :: IO AsciiOutput
-getAsciiOut = getAsciiOut' $ MonkyPlain " | "
+getAsciiOut = getAsciiOutDiv $ MonkyPlain " | "
 
 -- |Get an output handle for ascii formatting
-getAsciiOut'
+getAsciiOutDiv
   :: MonkyOut -- ^The Divider
   -> IO AsciiOutput
-getAsciiOut' = return . AsciiOutput
+getAsciiOutDiv = return . AsciiOutput

--- a/Monky/Outputs/Ascii.hs
+++ b/Monky/Outputs/Ascii.hs
@@ -62,7 +62,7 @@ instance MonkyOutput AsciiOutput where
     doOut d
     doLine h xs
 
--- |Get an output handle for ascii formatting. Divider Defaults to " | "
+-- |Get an output handle for ascii formatting. Divider Defaults to @" | "@
 getAsciiOut :: IO AsciiOutput
 getAsciiOut = getAsciiOut' $ MonkyPlain " | "
 

--- a/Monky/Outputs/Dzen2.hs
+++ b/Monky/Outputs/Dzen2.hs
@@ -43,10 +43,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 -- |The output handle for dzen2 pipe
-data DzenOutput = DzenOutput
-    Int -- ^The height of the Dzen bar
-    Text -- ^Path to the xbm folder
-    MonkyOut -- ^Segment Divider
+data DzenOutput = DzenOutput Int Text MonkyOut
 
 doOut :: DzenOutput -> MonkyOut -> IO ()
 doOut _ (MonkyPlain t) = T.putStr t

--- a/Monky/Outputs/Dzen2.hs
+++ b/Monky/Outputs/Dzen2.hs
@@ -30,7 +30,7 @@ module Monky.Outputs.Dzen2
   ( DzenOutput
   , getDzenOut
   , getDzenOut'
-  , getDzenOut''
+  , getDzenOutDiv
   )
 where
 
@@ -102,9 +102,9 @@ getDzenOut' h = do
     getDzenOut h (T.pack pwd `T.append` "/xbm/")
 
 -- |Get an output handle for dzen2 formatting
-getDzenOut''
+getDzenOutDiv
     :: Int -- ^The height of your dzen bar in pixel (required for block-drawing)
     -> Text -- ^Path to the directory containing your .xbm files.
     -> MonkyOut -- ^Divider
     -> IO DzenOutput
-getDzenOut'' h p d = return $ DzenOutput h (T.append p "/") d
+getDzenOutDiv h p d = return $ DzenOutput h (T.append p "/") d

--- a/Monky/Outputs/Dzen2.hs
+++ b/Monky/Outputs/Dzen2.hs
@@ -84,7 +84,7 @@ instance MonkyOutput DzenOutput where
     doLine h xs
 
 -- |Get an output handle for dzen2 formatting
--- |Assumes " | " as divider
+-- Assumes @" | "@ as divider
 getDzenOut
   :: Int -- ^The height of your dzen bar in pixel (required for block-drawing)
   -> Text -- ^Path to the directory cointaining your .xbm files.
@@ -93,7 +93,7 @@ getDzenOut h p = return $ DzenOutput h (T.append p "/") $ MonkyPlain " | "
 
 
 -- |Get the output handle for dzen2 formatting. Will asume your .xbm files are
--- |in <monkydir>/xbm/
+-- in \<monkydir\>\/xbm\/
 getDzenOut'
     :: Int -- ^The height of your dzen bar in pixel (for block drawing)
     -> IO DzenOutput

--- a/Monky/Outputs/Guess.hs
+++ b/Monky/Outputs/Guess.hs
@@ -31,7 +31,7 @@ Portability : Linux
 module Monky.Outputs.Guess
   ( guessOutput
   , GuessOut
-  , guessOutput'
+  , guessOutputDiv
   )
 where
 
@@ -48,7 +48,7 @@ import System.Posix.Files (readSymbolicLink)
 import Monky.Modules
 import Monky.Outputs.Fallback (chooseTerminalOut)
 import Monky.Outputs.Show (getShowOut)
-import Monky.Outputs.Dzen2 (getDzenOut'')
+import Monky.Outputs.Dzen2 (getDzenOutDiv)
 import Monky.Outputs.I3 (getI3Output)
 import Monky.Outputs.Serialize (getSerializeOut)
 
@@ -128,7 +128,7 @@ chooseProcessOut
   -> String
   -> IO GuessOut
 chooseProcessOut height path divider x
-  | x == "dzen2" = GO <$> getDzenOut'' height path divider
+  | x == "dzen2" = GO <$> getDzenOutDiv height path divider
   | x == "i3bar" = GO <$> getI3Output
   | x `elem`networkOuts = GO <$> getSerializeOut
   | otherwise = GO <$> getShowOut
@@ -138,15 +138,15 @@ guessOutput
   :: Int -- ^Dzen height
   -> Text -- ^Dzen xbm path
   -> IO GuessOut
-guessOutput height path = guessOutput' height path $ MonkyPlain " | "
+guessOutput height path = guessOutputDiv height path $ MonkyPlain " | "
 
 -- | Guess output based on isatty and other side of the stdout fd
-guessOutput'
+guessOutputDiv
   :: Int -- ^Dzen height
   -> Text -- ^Dzen xbm path
   -> MonkyOut -- ^The Divider to use
   -> IO GuessOut
-guessOutput' height path divider = do
+guessOutputDiv height path divider = do
   out <- getOutputType
   case out of
     Terminal -> GO <$> chooseTerminalOut

--- a/Monky/Outputs/Utf8.hs
+++ b/Monky/Outputs/Utf8.hs
@@ -65,7 +65,7 @@ instance MonkyOutput Utf8Output where
     doOut d
     doLine h xs
 
--- |Get an output handle for utf8 formatting. Divider defaults to " | "
+-- |Get an output handle for utf8 formatting. Divider defaults to @" | "@
 getUtf8Out :: IO Utf8Output
 getUtf8Out = getUtf8Out' $ MonkyPlain " | "
 

--- a/Monky/Outputs/Utf8.hs
+++ b/Monky/Outputs/Utf8.hs
@@ -29,7 +29,7 @@ This module provides the output generation for utf8 outputs
 module Monky.Outputs.Utf8
   ( Utf8Output
   , getUtf8Out
-  , getUtf8Out'
+  , getUtf8OutDiv
   )
 where
 
@@ -67,11 +67,11 @@ instance MonkyOutput Utf8Output where
 
 -- |Get an output handle for utf8 formatting. Divider defaults to @" | "@
 getUtf8Out :: IO Utf8Output
-getUtf8Out = getUtf8Out' $ MonkyPlain " | "
+getUtf8Out = getUtf8OutDiv $ MonkyPlain " | "
 
 
 -- |Get an output handle for utf8 formatting.
-getUtf8Out'
+getUtf8OutDiv
   :: MonkyOut -- ^The divider between segments
   -> IO Utf8Output
-getUtf8Out' = return . Utf8Output
+getUtf8OutDiv = return . Utf8Output

--- a/Monky/Outputs/Utf8.hs
+++ b/Monky/Outputs/Utf8.hs
@@ -17,7 +17,6 @@
     along with Monky.  If not, see <http://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-|
 Module      : Monky.Outputs.Utf8
 Description : Output module for utf8
@@ -30,6 +29,7 @@ This module provides the output generation for utf8 outputs
 module Monky.Outputs.Utf8
   ( Utf8Output
   , getUtf8Out
+  , getUtf8Out'
   )
 where
 
@@ -40,11 +40,11 @@ import Monky.Outputs.Unicode
 import qualified Data.Text.IO as T
 
 -- |The output handle for a utf8 pipe
-data Utf8Output = Utf8Output
+data Utf8Output = Utf8Output MonkyOut
 
 doOut :: MonkyOut -> IO ()
 doOut (MonkyPlain t)   = T.putStr t
-doOut (MonkyImage _ c)   = putChar c -- Images are not supported :(
+doOut (MonkyImage _ c) = putChar c -- Images are not supported :(
 doOut (MonkyBar p)     = putChar (barChar p)
 doOut (MonkyHBar p)    = do
   putStr $ replicate (p `div` 10) '█'
@@ -60,11 +60,18 @@ instance MonkyOutput Utf8Output where
     doSegment x
     putStr "\n"
     hFlush stdout
-  doLine h (x:xs) = do
+  doLine h@(Utf8Output d) (x:xs) = do
     doSegment x
-    putStr " | "
+    doOut d
     doLine h xs
 
--- |Get an output handle for utf8 formatting
+-- |Get an output handle for utf8 formatting. Divider defaults to " | "
 getUtf8Out :: IO Utf8Output
-getUtf8Out = return Utf8Output
+getUtf8Out = getUtf8Out' $ MonkyPlain " | "
+
+
+-- |Get an output handle for utf8 formatting.
+getUtf8Out'
+  :: MonkyOut -- ^The divider between segments
+  -> IO Utf8Output
+getUtf8Out' = return . Utf8Output

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+2.1.3:
+	Add option to change section divider in Dzen2, Ascii, Utf8 and Guess out.
+
 2.1.0:
   Add pulseaudio support and deprecate old Alsa Example location
   Fix Battery colours (only <20 worked earlier)

--- a/monky.cabal
+++ b/monky.cabal
@@ -10,7 +10,7 @@ name:                monky
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.1.2.0
+version:             2.1.3.0
 
 -- The ABOVE LINE has to stay AS IS (except for version changes) for the
 -- template to work properly


### PR DESCRIPTION
adds:

```haskell
getAsciiOutDiv
  :: MonkyOut -- ^The Divider
  -> IO AsciiOutput
```
```haskell
getDzenOutDiv
    :: Int -- ^The height of your dzen bar in pixel (required for block-drawing)
    -> Text -- ^Path to the directory containing your .xbm files.
    -> MonkyOut -- ^Divider
    -> IO DzenOutput
```
```haskell
guessOutputDiv
  :: Int -- ^Dzen height
  -> Text -- ^Dzen xbm path
  -> MonkyOut -- ^The Divider to use
  -> IO GuessOut
```
```haskell
getUtf8OutDiv
  :: MonkyOut -- ^The divider between segments
  -> IO Utf8Output
```

Example usage:
```haskell
main :: IO ()
main = startLoop (getDzenOutDiv 16 "/home/belst/.monky/xbm/" $ MonkyPlain " \xe0b3 ")
  [ pollPack 1 $ getCPUHandle' ScalingCur
  , pollPack 5 $ getMemoryBarHandle 2
  , evtPack    $ getVOLHandle "default"
  , evtPack    $ getModifyHandle modifyMPD $ getMPDHandle "127.0.0.1" "6600"
  , pollPack 5 $ getBatteryHandle "ACAD" "BAT1"
  , pollPack 1 $ getFancyTimeHandle timeStr
  ]
```
![](https://ptpb.pw/bn3J.png)